### PR TITLE
Read configuration for the app directly from the k8s API

### DIFF
--- a/cmd/network-operator-init-container/app/options/options.go
+++ b/cmd/network-operator-init-container/app/options/options.go
@@ -32,9 +32,11 @@ func New() *Options {
 
 // Options contains application options
 type Options struct {
-	NodeName   string
-	ConfigPath string
-	LogConfig  *logsapi.LoggingConfiguration
+	NodeName           string
+	ConfigMapName      string
+	ConfigMapNamespace string
+	ConfigMapKey       string
+	LogConfig          *logsapi.LoggingConfiguration
 }
 
 // AddNamedFlagSets returns FlagSet for Options
@@ -42,8 +44,12 @@ func (o *Options) AddNamedFlagSets(sharedFS *cliflag.NamedFlagSets) {
 	configFS := sharedFS.FlagSet("Config")
 	configFS.StringVar(&o.NodeName, "node-name", "",
 		"name of the k8s node on which this app runs")
-	configFS.StringVar(&o.ConfigPath, "config", "",
-		"path to the configuration file")
+	configFS.StringVar(&o.ConfigMapName, "configmap-name", "",
+		"name of the configmap with configuration for the app")
+	configFS.StringVar(&o.ConfigMapNamespace, "configmap-namespace", "",
+		"namespace of the configmap with configuration for the app")
+	configFS.StringVar(&o.ConfigMapKey, "configmap-key", "config.json",
+		"key inside the configmap with configuration for the app")
 
 	logFS := sharedFS.FlagSet("Logging")
 	logsapi.AddFlags(o.LogConfig, logFS)
@@ -68,8 +74,16 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("node-name is required parameter")
 	}
 
-	if o.ConfigPath == "" {
-		return fmt.Errorf("config is required parameter")
+	if o.ConfigMapName == "" {
+		return fmt.Errorf("configmap-name is required parameter")
+	}
+
+	if o.ConfigMapNamespace == "" {
+		return fmt.Errorf("configmap-namespace is required parameter")
+	}
+
+	if o.ConfigMapKey == "" {
+		return fmt.Errorf("configmap-key is required parameter")
 	}
 
 	if err = logsapi.ValidateAndApply(o.LogConfig, nil); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,19 +15,14 @@ package config
 
 import (
 	"fmt"
-	"os"
 
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
-// FromFile reads configuration from the file
-func FromFile(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read data from the provided file: %v", err)
-	}
+// Load parse configuration from the provided string
+func Load(config string) (*Config, error) {
 	cfg := &Config{}
-	if err := json.Unmarshal(data, cfg); err != nil {
+	if err := json.Unmarshal([]byte(config), cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal configuration: %v", err)
 	}
 	if err := cfg.Validate(); err != nil {


### PR DESCRIPTION
This is required to avoid possible issues caused by ConfigMap cache in kubelet.