### PR TITLE
chore: bump nvidia/distroless/go from v3.1.9 to v3.1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /workspace
 # Build with make to apply all build logic defined in Makefile
 RUN make build
 
-FROM nvcr.io/nvidia/distroless/go:v3.1.9
+FROM nvcr.io/nvidia/distroless/go:v3.1.10
 WORKDIR /
 COPY --from=builder /workspace/build/network-operator-init-container .
 


### PR DESCRIPTION
Bumps nvidia/distroless/go from v3.1.9 to v3.1.10.

---
updated-dependencies:
- dependency-name: nvidia/distroless/go dependency-version: v3.1.10 dependency-type: direct:production ...