### PR TITLE
fix: pin setup-envtest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ DOCKER_CMD ?= docker
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
+SETUP_ENVTEST_VERSION ?= release-0.21
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -114,7 +116,7 @@ GOLANGCILINT_VERSION ?= v1.64.8
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): | $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCILINT) ## Download golangci-lint locally if necessary.


### PR DESCRIPTION
Latest setup-envtest requires go 1.25

go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251020210837-fb2beabd029b requires go >= 1.25.0 (running go 1.24.7; GOTOOLCHAIN=local)