### PR TITLE
Add storage module detection and mlx5 prefix greenlisting to pre-flight checks

### DIFF
--- a/cmd/network-operator-init-container/app/app.go
+++ b/cmd/network-operator-init-container/app/app.go
@@ -260,10 +260,14 @@ func runModuleDependencyCheck(ctx context.Context, initContCfg *configPgk.Config
 	if initContCfg.ModuleDependencyCheck.UnloadThirdPartyRDMA {
 		logger.Info("UNLOAD_THIRD_PARTY_RDMA_MODULES is enabled; known third-party RDMA modules will be skipped")
 	}
+	if initContCfg.ModuleDependencyCheck.UnloadStorageModules {
+		logger.Info("UNLOAD_STORAGE_MODULES is enabled; known storage modules will be skipped")
+	}
 
 	checker := modules.NewChecker(
 		initContCfg.ModuleDependencyCheck.Modules,
 		initContCfg.ModuleDependencyCheck.UnloadThirdPartyRDMA,
+		initContCfg.ModuleDependencyCheck.UnloadStorageModules,
 		procPath, sysPath, logger)
 
 	report, err := checker.RunAllChecks(ctx)
@@ -280,7 +284,8 @@ func runModuleDependencyCheck(ctx context.Context, initContCfg *configPgk.Config
 
 // reportPreFlightIssues logs all pre-flight check issues and returns an error if any were found.
 func reportPreFlightIssues(logger logr.Logger, report *modules.DependencyReport) error {
-	totalIssues := len(report.ThirdPartyRDMA) + len(report.UnknownKernelModules) + len(report.UserspaceIssues)
+	totalIssues := len(report.ThirdPartyRDMA) + len(report.StorageModules) +
+		len(report.UnknownKernelModules) + len(report.UserspaceIssues)
 	if totalIssues == 0 {
 		return nil
 	}
@@ -298,6 +303,21 @@ func reportPreFlightIssues(logger logr.Logger, report *modules.DependencyReport)
 				"NicClusterPolicy ofedDriver env vars to automatically unload known third-party "+
 				"RDMA modules before driver reload. Verify that no running workloads depend on "+
 				"these modules before enabling.")
+	}
+
+	// Category 1b: known storage-over-RDMA modules (automatable via UNLOAD_STORAGE_MODULES)
+	if len(report.StorageModules) > 0 {
+		for _, dep := range report.StorageModules {
+			logger.Error(fmt.Errorf("storage module dependency"),
+				"storage-over-RDMA module blocking MOFED driver reload",
+				"mofedModule", dep.MofedModule,
+				"dependents", strings.Join(dep.Dependents, ", "))
+		}
+		logger.Error(fmt.Errorf("storage modules require configuration change"),
+			"Recommended action: set UNLOAD_STORAGE_MODULES=\"true\" in "+
+				"NicClusterPolicy ofedDriver env vars to automatically unload known "+
+				"storage-over-RDMA modules before driver reload. Verify that no running "+
+				"workloads depend on these modules before enabling.")
 	}
 
 	// Category 2: unknown kernel modules (error level — manual intervention)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,8 @@ type ModuleDependencyCheckConfig struct {
 	Modules []string `json:"modules"`
 	// when true, all known third-party RDMA modules are treated as allowed (driver will handle them)
 	UnloadThirdPartyRDMA bool `json:"unloadThirdPartyRdma"`
+	// when true, all known storage-over-RDMA modules are treated as allowed (driver will handle them)
+	UnloadStorageModules bool `json:"unloadStorageModules"`
 	// path to the host's /proc filesystem mount inside the container
 	HostProcPath string `json:"hostProcPath"`
 	// path to the host's /sys filesystem mount inside the container

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -94,6 +94,27 @@ var _ = Describe("Config test", func() {
 		Expect(cfg.ModuleDependencyCheck.Modules).To(Equal([]string{"mlx5_core", "ib_core"}))
 		Expect(cfg.ModuleDependencyCheck.UnloadThirdPartyRDMA).To(BeTrue())
 	})
+	It("Valid - moduleDependencyCheck enabled with UnloadStorageModules", func() {
+		cfg, err := configPgk.Load(createConfig(&configPgk.Config{
+			ModuleDependencyCheck: configPgk.ModuleDependencyCheckConfig{
+				Enable:               true,
+				Modules:              []string{"mlx5_core", "ib_core"},
+				UnloadStorageModules: true,
+				HostProcPath:         "/host/proc",
+				HostSysPath:          "/host/sys",
+			},
+		}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.ModuleDependencyCheck.Enable).To(BeTrue())
+		Expect(cfg.ModuleDependencyCheck.UnloadStorageModules).To(BeTrue())
+		Expect(cfg.ModuleDependencyCheck.UnloadThirdPartyRDMA).To(BeFalse())
+	})
+	It("Backward compatible - old config without unloadStorageModules field defaults to false", func() {
+		oldJSON := `{"safeDriverLoad":{"enable":false},"moduleDependencyCheck":{"enable":true,"modules":["ib_core"]}}`
+		cfg, err := configPgk.Load(oldJSON)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.ModuleDependencyCheck.UnloadStorageModules).To(BeFalse())
+	})
 	It("Logical validation failed - moduleDependencyCheck enabled with no modules", func() {
 		_, err := configPgk.Load(createConfig(&configPgk.Config{
 			ModuleDependencyCheck: configPgk.ModuleDependencyCheckConfig{

--- a/pkg/modules/checker.go
+++ b/pkg/modules/checker.go
@@ -46,10 +46,23 @@ var KnownThirdPartyRDMAModules = map[string]struct{}{
 	"rdma_rxe": {}, "siw": {}, "vmw_pvrdma": {},
 }
 
-// DependencyReport contains the 3-tier classification of blocking dependencies.
+// KnownStorageModules is the set of storage-over-RDMA kernel modules that can block
+// MOFED driver reload. When UnloadStorageModules is true these are treated as allowed
+// and the driver container will handle their unloading via UNLOAD_STORAGE_MODULES.
+//
+// This list must be kept in sync with doca-driver-build's StorageModules
+// (entrypoint/internal/config/config.go, STORAGE_MODULES env var).
+var KnownStorageModules = map[string]struct{}{
+	"ib_isert": {}, "nvme_rdma": {}, "nvmet_rdma": {},
+	"rpcrdma": {}, "xprtrdma": {}, "ib_srpt": {},
+}
+
+// DependencyReport contains the classified blocking dependencies.
 type DependencyReport struct {
-	// Category 1: Known third-party RDMA modules — can be auto-unloaded
+	// Category 1a: Known third-party RDMA modules — can be auto-unloaded
 	ThirdPartyRDMA []Dependency
+	// Category 1b: Known storage-over-RDMA modules — can be auto-unloaded
+	StorageModules []Dependency
 	// Category 2: Unknown kernel modules — user must handle manually
 	UnknownKernelModules []Dependency
 	// Category 3: Userspace references — user must identify and stop processes
@@ -71,6 +84,7 @@ type Dependency struct {
 type Checker struct {
 	modules              map[string]struct{}
 	unloadThirdPartyRDMA bool
+	unloadStorageModules bool
 	hostProcPath         string
 	hostSysPath          string
 	logger               logr.Logger
@@ -80,9 +94,11 @@ type Checker struct {
 // modules is the list of MOFED kernel modules to check for external dependencies.
 // unloadThirdPartyRDMA controls whether known third-party RDMA modules are treated
 // as allowed (the driver container will handle their unloading).
+// unloadStorageModules controls whether known storage-over-RDMA modules are treated
+// as allowed (the driver container will handle their unloading).
 // hostProcPath and hostSysPath are paths to the host's /proc and /sys mounts.
 func NewChecker(
-	modules []string, unloadThirdPartyRDMA bool,
+	modules []string, unloadThirdPartyRDMA bool, unloadStorageModules bool,
 	hostProcPath, hostSysPath string, logger logr.Logger,
 ) *Checker {
 	moduleSet := make(map[string]struct{}, len(modules))
@@ -92,6 +108,7 @@ func NewChecker(
 	return &Checker{
 		modules:              moduleSet,
 		unloadThirdPartyRDMA: unloadThirdPartyRDMA,
+		unloadStorageModules: unloadStorageModules,
 		hostProcPath:         hostProcPath,
 		hostSysPath:          hostSysPath,
 		logger:               logger,
@@ -337,10 +354,13 @@ func (c *Checker) CheckDependencies(ctx context.Context) ([]Dependency, error) {
 }
 
 // RunAllChecks performs BFS dependency detection and userspace detection, then
-// classifies each blocking issue into one of three categories:
-//   - Category 1: Known third-party RDMA modules (auto-unloadable when flag is set)
+// classifies each blocking issue into one of four categories:
+//   - Category 1a: Known third-party RDMA modules (auto-unloadable when flag is set)
+//   - Category 1b: Known storage-over-RDMA modules (auto-unloadable when flag is set)
 //   - Category 2: Unknown kernel modules (manual intervention required)
 //   - Category 3: Userspace processes holding modules open
+//
+// Modules with an "mlx5" prefix are NVIDIA's own modules and are always silently skipped.
 func (c *Checker) RunAllChecks(ctx context.Context) (*DependencyReport, error) {
 	report := &DependencyReport{}
 
@@ -353,23 +373,37 @@ func (c *Checker) RunAllChecks(ctx context.Context) (*DependencyReport, error) {
 	// Step 2: Classify kernel module dependencies
 	for _, dep := range allDeps {
 		var thirdParty []string
+		var storage []string
 		var unknown []string
 		for _, d := range dep.Dependents {
+			// mlx5-prefixed modules are NVIDIA's own — always greenlit
+			if strings.HasPrefix(d, "mlx5") {
+				continue
+			}
 			if _, isKnown := KnownThirdPartyRDMAModules[d]; isKnown {
 				if !c.unloadThirdPartyRDMA {
-					// Category 1: known RDMA but flag not set
 					thirdParty = append(thirdParty, d)
 				}
-				// If unloadThirdPartyRDMA is true, skip — driver will handle
-			} else {
-				// Category 2: unknown module
-				unknown = append(unknown, d)
+				continue
 			}
+			if _, isStorage := KnownStorageModules[d]; isStorage {
+				if !c.unloadStorageModules {
+					storage = append(storage, d)
+				}
+				continue
+			}
+			unknown = append(unknown, d)
 		}
 		if len(thirdParty) > 0 {
 			report.ThirdPartyRDMA = append(report.ThirdPartyRDMA, Dependency{
 				MofedModule: dep.MofedModule,
 				Dependents:  thirdParty,
+			})
+		}
+		if len(storage) > 0 {
+			report.StorageModules = append(report.StorageModules, Dependency{
+				MofedModule: dep.MofedModule,
+				Dependents:  storage,
 			})
 		}
 		if len(unknown) > 0 {

--- a/pkg/modules/checker_test.go
+++ b/pkg/modules/checker_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Checker", func() {
 
 	It("should return no dependencies when no modules are loaded", func() {
 		writeProcModules(procDir, "")
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(BeEmpty())
@@ -106,7 +106,7 @@ rdma_cm 111111 0 - Live 0xffffffffa0300000
 		createEmptyHolders(sysDir, "ib_core")
 		createEmptyHolders(sysDir, "rdma_cm")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(BeEmpty())
@@ -120,7 +120,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 		createHolder(sysDir, "ib_core", "ko2iblnd")
 		createEmptyHolders(sysDir, "ko2iblnd")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(HaveLen(1))
@@ -138,7 +138,7 @@ ext_mod 99999 0 - Live 0xffffffffa0500000
 		createHolder(sysDir, "ko2iblnd", "ext_mod")
 		createEmptyHolders(sysDir, "ext_mod")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(HaveLen(1))
@@ -159,7 +159,7 @@ app 22222 0 - Live 0xffffffffa0800000
 		createHolder(sysDir, "storageA", "app")
 		createEmptyHolders(sysDir, "app")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(HaveLen(1))
@@ -175,7 +175,7 @@ mlx5_ib 456789 0 - Live 0xffffffffa0100000
 		createHolder(sysDir, "ib_core", "mlx5_ib")
 		createEmptyHolders(sysDir, "mlx5_ib")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(BeEmpty())
@@ -186,7 +186,7 @@ mlx5_ib 456789 0 - Live 0xffffffffa0100000
 `)
 		// No sysfs entries for MOFED modules at all
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(BeEmpty())
@@ -201,7 +201,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 		createHolder(sysDir, "ib_core", "ko2iblnd")
 		createEmptyHolders(sysDir, "ko2iblnd")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(HaveLen(1))
@@ -211,7 +211,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 
 	It("should handle missing /proc/modules file gracefully", func() {
 		// procDir exists but has no modules file — no error, empty result
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deps).To(BeEmpty())
@@ -225,7 +225,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 		createHolder(sysDir, "ib_core", "ko2iblnd")
 		createEmptyHolders(sysDir, "ko2iblnd")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		// ko2iblnd is not in KnownThirdPartyRDMAModules, so CheckDependencies still reports it
@@ -240,7 +240,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 			writeProcModules(procDir, "ib_umad 28672 2 mlx5_ib 0x00000000\n")
 			createHolder(sysDir, "ib_umad", "mlx5_ib")
 
-			checker := modules.NewChecker([]string{"ib_umad"}, false, procDir, sysDir, logger)
+			checker := modules.NewChecker([]string{"ib_umad"}, false, false, procDir, sysDir, logger)
 			issues, err := checker.CheckUserspaceUsers(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(issues).To(HaveLen(1))
@@ -256,7 +256,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 			writeProcModules(procDir, "ib_umad 28672 1 mlx5_ib 0x00000000\n")
 			createHolder(sysDir, "ib_umad", "mlx5_ib")
 
-			checker := modules.NewChecker([]string{"ib_umad"}, false, procDir, sysDir, logger)
+			checker := modules.NewChecker([]string{"ib_umad"}, false, false, procDir, sysDir, logger)
 			issues, err := checker.CheckUserspaceUsers(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(issues).To(BeEmpty())
@@ -267,7 +267,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 			writeProcModules(procDir, "ib_umad 28672 0 - 0x00000000\n")
 			createEmptyHolders(sysDir, "ib_umad")
 
-			checker := modules.NewChecker([]string{"ib_umad"}, false, procDir, sysDir, logger)
+			checker := modules.NewChecker([]string{"ib_umad"}, false, false, procDir, sysDir, logger)
 			issues, err := checker.CheckUserspaceUsers(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(issues).To(BeEmpty())
@@ -277,7 +277,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 			// No entry for ib_umad in /proc/modules
 			writeProcModules(procDir, "some_other_mod 1234 0 - 0x00000000\n")
 
-			checker := modules.NewChecker([]string{"ib_umad"}, false, procDir, sysDir, logger)
+			checker := modules.NewChecker([]string{"ib_umad"}, false, false, procDir, sysDir, logger)
 			issues, err := checker.CheckUserspaceUsers(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(issues).To(BeEmpty())
@@ -294,7 +294,7 @@ ko2iblnd 55555 0 - Live 0xffffffffa0400000
 			createEmptyHolders(sysDir, "ib_uverbs")
 			createHolder(sysDir, "ib_core", "mlx5_ib")
 
-			checker := modules.NewChecker([]string{"ib_umad", "ib_uverbs", "ib_core"}, false, procDir, sysDir, logger)
+			checker := modules.NewChecker([]string{"ib_umad", "ib_uverbs", "ib_core"}, false, false, procDir, sysDir, logger)
 			issues, err := checker.CheckUserspaceUsers(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(issues).To(HaveLen(2))
@@ -325,7 +325,7 @@ ext_c 33333 0 - Live 0xffffffffa0b00000
 		createEmptyHolders(sysDir, "ext_a")
 		createEmptyHolders(sysDir, "ext_c")
 
-		checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+		checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 		deps, err := checker.CheckDependencies(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -337,19 +337,20 @@ ext_c 33333 0 - Live 0xffffffffa0b00000
 	})
 
 	Context("RunAllChecks", func() {
-		It("should classify known RDMA module (qedr) as Category 1", func() {
+		It("should classify known RDMA module (qedr) as Category 1a", func() {
 			writeProcModules(procDir, `ib_core 789012 1 qedr, Live 0xffffffffa0200000
 qedr 55555 0 - Live 0xffffffffa0400000
 `)
 			createHolder(sysDir, "ib_core", "qedr")
 			createEmptyHolders(sysDir, "qedr")
 
-			checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+			checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 			report, err := checker.RunAllChecks(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(report.ThirdPartyRDMA).To(HaveLen(1))
 			Expect(report.ThirdPartyRDMA[0].MofedModule).To(Equal("ib_core"))
 			Expect(report.ThirdPartyRDMA[0].Dependents).To(ConsistOf("qedr"))
+			Expect(report.StorageModules).To(BeEmpty())
 			Expect(report.UnknownKernelModules).To(BeEmpty())
 			Expect(report.UserspaceIssues).To(BeEmpty())
 		})
@@ -361,10 +362,11 @@ my_driver 55555 0 - Live 0xffffffffa0400000
 			createHolder(sysDir, "ib_core", "my_driver")
 			createEmptyHolders(sysDir, "my_driver")
 
-			checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+			checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 			report, err := checker.RunAllChecks(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(BeEmpty())
 			Expect(report.UnknownKernelModules).To(HaveLen(1))
 			Expect(report.UnknownKernelModules[0].MofedModule).To(Equal("ib_core"))
 			Expect(report.UnknownKernelModules[0].Dependents).To(ConsistOf("my_driver"))
@@ -378,10 +380,11 @@ my_driver 55555 0 - Live 0xffffffffa0400000
 			createHolder(sysDir, "ib_umad", "mlx5_ib")
 			createEmptyHolders(sysDir, "mlx5_ib")
 
-			checker := modules.NewChecker([]string{"ib_umad", "mlx5_ib"}, false, procDir, sysDir, logger)
+			checker := modules.NewChecker([]string{"ib_umad", "mlx5_ib"}, false, false, procDir, sysDir, logger)
 			report, err := checker.RunAllChecks(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(BeEmpty())
 			Expect(report.UnknownKernelModules).To(BeEmpty())
 			Expect(report.UserspaceIssues).To(HaveLen(1))
 			Expect(report.UserspaceIssues[0].Module).To(Equal("ib_umad"))
@@ -395,33 +398,116 @@ qedr 55555 0 - Live 0xffffffffa0400000
 			createHolder(sysDir, "ib_core", "qedr")
 			createEmptyHolders(sysDir, "qedr")
 
-			checker := modules.NewChecker(mofedModules, true, procDir, sysDir, logger)
+			checker := modules.NewChecker(mofedModules, true, false, procDir, sysDir, logger)
 			report, err := checker.RunAllChecks(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(BeEmpty())
 			Expect(report.UnknownKernelModules).To(BeEmpty())
 			Expect(report.UserspaceIssues).To(BeEmpty())
 		})
 
-		It("should report mix of all three categories", func() {
-			// qedr (known RDMA) -> Cat 1; my_driver (unknown) -> Cat 2; ib_umad refcount mismatch -> Cat 3
-			writeProcModules(procDir, `ib_core 789012 2 qedr,my_driver, Live 0xffffffffa0200000
-qedr 55555 0 - Live 0xffffffffa0400000
+		It("should classify storage module (nvme_rdma) as Category 1b when flag is false", func() {
+			writeProcModules(procDir, `ib_core 789012 1 nvme_rdma, Live 0xffffffffa0200000
+nvme_rdma 55555 0 - Live 0xffffffffa0400000
+`)
+			createHolder(sysDir, "ib_core", "nvme_rdma")
+			createEmptyHolders(sysDir, "nvme_rdma")
+
+			checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
+			report, err := checker.RunAllChecks(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(HaveLen(1))
+			Expect(report.StorageModules[0].MofedModule).To(Equal("ib_core"))
+			Expect(report.StorageModules[0].Dependents).To(ConsistOf("nvme_rdma"))
+			Expect(report.UnknownKernelModules).To(BeEmpty())
+			Expect(report.UserspaceIssues).To(BeEmpty())
+		})
+
+		It("should skip storage module when unloadStorageModules=true", func() {
+			writeProcModules(procDir, `ib_core 789012 1 nvme_rdma, Live 0xffffffffa0200000
+nvme_rdma 55555 0 - Live 0xffffffffa0400000
+`)
+			createHolder(sysDir, "ib_core", "nvme_rdma")
+			createEmptyHolders(sysDir, "nvme_rdma")
+
+			checker := modules.NewChecker(mofedModules, false, true, procDir, sysDir, logger)
+			report, err := checker.RunAllChecks(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(BeEmpty())
+			Expect(report.UnknownKernelModules).To(BeEmpty())
+			Expect(report.UserspaceIssues).To(BeEmpty())
+		})
+
+		It("should silently greenlit mlx5-prefixed module", func() {
+			// mlx5_vdpa depends on mlx5_core (MOFED) but is not in the MOFED module list
+			writeProcModules(procDir, `mlx5_core 1234567 1 mlx5_vdpa, Live 0xffffffffa0000000
+mlx5_vdpa 55555 0 - Live 0xffffffffa0400000
+`)
+			createHolder(sysDir, "mlx5_core", "mlx5_vdpa")
+			createEmptyHolders(sysDir, "mlx5_vdpa")
+
+			checker := modules.NewChecker([]string{"mlx5_core"}, false, false, procDir, sysDir, logger)
+			report, err := checker.RunAllChecks(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(BeEmpty())
+			Expect(report.UnknownKernelModules).To(BeEmpty())
+			Expect(report.UserspaceIssues).To(BeEmpty())
+		})
+
+		It("should greenlit mlx5 prefix while reporting other blocking modules", func() {
+			writeProcModules(procDir, `mlx5_core 1234567 2 mlx5_vdpa,my_driver, Live 0xffffffffa0000000
+mlx5_vdpa 55555 0 - Live 0xffffffffa0400000
 my_driver 44444 0 - Live 0xffffffffa0500000
+`)
+			createHolder(sysDir, "mlx5_core", "mlx5_vdpa")
+			createHolder(sysDir, "mlx5_core", "my_driver")
+			createEmptyHolders(sysDir, "mlx5_vdpa")
+			createEmptyHolders(sysDir, "my_driver")
+
+			checker := modules.NewChecker([]string{"mlx5_core"}, false, false, procDir, sysDir, logger)
+			report, err := checker.RunAllChecks(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(BeEmpty())
+			Expect(report.UnknownKernelModules).To(HaveLen(1))
+			Expect(report.UnknownKernelModules[0].Dependents).To(ConsistOf("my_driver"))
+			Expect(report.UserspaceIssues).To(BeEmpty())
+		})
+
+		It("should report mix of all four kernel module categories", func() {
+			// qedr (known RDMA) -> Cat 1a; nvme_rdma (storage) -> Cat 1b;
+			// my_driver (unknown) -> Cat 2; mlx5_vdpa (greenlit) -> skipped;
+			// ib_umad refcount mismatch -> Cat 3
+			writeProcModules(procDir, `ib_core 789012 3 qedr,nvme_rdma,my_driver, Live 0xffffffffa0200000
+mlx5_core 1234567 1 mlx5_vdpa, Live 0xffffffffa0000000
+qedr 55555 0 - Live 0xffffffffa0400000
+nvme_rdma 66666 0 - Live 0xffffffffa0600000
+my_driver 44444 0 - Live 0xffffffffa0500000
+mlx5_vdpa 77777 0 - Live 0xffffffffa0700000
 ib_umad 28672 2 mlx5_ib 0x00000000
 `)
 			createHolder(sysDir, "ib_core", "qedr")
+			createHolder(sysDir, "ib_core", "nvme_rdma")
 			createHolder(sysDir, "ib_core", "my_driver")
+			createHolder(sysDir, "mlx5_core", "mlx5_vdpa")
 			createEmptyHolders(sysDir, "qedr")
+			createEmptyHolders(sysDir, "nvme_rdma")
 			createEmptyHolders(sysDir, "my_driver")
+			createEmptyHolders(sysDir, "mlx5_vdpa")
 			createHolder(sysDir, "ib_umad", "mlx5_ib")
 
 			checker := modules.NewChecker([]string{"mlx5_core", "mlx5_ib", "ib_core", "rdma_cm", "ib_umad"},
-				false, procDir, sysDir, logger)
+				false, false, procDir, sysDir, logger)
 			report, err := checker.RunAllChecks(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(report.ThirdPartyRDMA).To(HaveLen(1))
 			Expect(report.ThirdPartyRDMA[0].Dependents).To(ConsistOf("qedr"))
+			Expect(report.StorageModules).To(HaveLen(1))
+			Expect(report.StorageModules[0].Dependents).To(ConsistOf("nvme_rdma"))
 			Expect(report.UnknownKernelModules).To(HaveLen(1))
 			Expect(report.UnknownKernelModules[0].Dependents).To(ConsistOf("my_driver"))
 			Expect(report.UserspaceIssues).To(HaveLen(1))
@@ -438,10 +524,11 @@ ib_core 789012 1 mlx5_ib, Live 0xffffffffa0200000
 			createEmptyHolders(sysDir, "mlx5_ib")
 			createHolder(sysDir, "ib_core", "mlx5_ib")
 
-			checker := modules.NewChecker(mofedModules, false, procDir, sysDir, logger)
+			checker := modules.NewChecker(mofedModules, false, false, procDir, sysDir, logger)
 			report, err := checker.RunAllChecks(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(report.ThirdPartyRDMA).To(BeEmpty())
+			Expect(report.StorageModules).To(BeEmpty())
 			Expect(report.UnknownKernelModules).To(BeEmpty())
 			Expect(report.UserspaceIssues).To(BeEmpty())
 		})


### PR DESCRIPTION
The init container's module dependency checker now classifies blocking dependencies into four tiers instead of three:

1a. Known third-party RDMA modules → recommend
    UNLOAD_THIRD_PARTY_RDMA_MODULES=true
1b. Known storage-over-RDMA modules (ib_isert, nvme_rdma,
    nvmet_rdma, rpcrdma, xprtrdma, ib_srpt) → recommend
    UNLOAD_STORAGE_MODULES=true (new)
2.  Unknown kernel modules → manual intervention
3.  Userspace processes → manual intervention

Previously storage modules fell into category 2, producing a misleading "manually unload or blacklist" message when the user just needs to set UNLOAD_STORAGE_MODULES=true. The driver container already checks and blocks on these modules — the init container now gives the same actionable guidance earlier, before the driver container starts.

Modules with an "mlx5" prefix (e.g. mlx5_vdpa, mlx5_netdev) are now silently greenlit. These are NVIDIA's own modules that may depend on mlx5_core but are not in the configured MOFED module list — they should never be reported as blocking.